### PR TITLE
Fix error, where `defaults` get mutated

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ var defaults = {
  * @api public
  */
 module.exports = function koaBetterBody(options) {
-  options = extend(true, defaults, options || {});
+  options = extend(true, {}, defaults, options || {});
 
   return function * main(next) {
     if (this.request.body !== undefined || this.request.method === 'GET') {


### PR DESCRIPTION
Before this every creation of a new instance of this middleware resulted in overwritten `defaults` object. This object should remain unchanged, so that different instances could be using different options, without explicitly stating the default values.

For example:

```
var mw1 = koaBetterBody({ fieldsKey: false });
var mw2 = koaBetterBody();
```

Before the fix, the `mw2` middleware has `fieldsKey` option set to `false` instead of `'fields'`. Now it should be correctly set as `'fields'`.
