### PR TITLE
Allowing `filesKey` to be set to `false`

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,18 +90,18 @@ function * handleRequest(that, opts) {
 
   var files = copy.files;
 
-  if (opts.fieldsKey === false) {
-    copy = copy.fields;
-  } else {
+  if (opts.fieldsKey) {
     var fields = copy.fields;
     copy = {};
     copy[opts.fieldsKey] = fields;
+  } else {
+    copy = copy.fields;
   }
 
-  if (opts.filesKey === false) {
-    extend(false, copy, files);
-  } else {
+  if (opts.filesKey) {
     copy[opts.filesKey] = files;
+  } else {
+    extend(false, copy, files);
   }
 
   return copy;

--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ function * handleRequest(that, opts) {
 
   var files = copy.files;
 
-  if (typeof opts.fieldsKey !== 'string') {
+  if (opts.fieldsKey === false) {
     copy = copy.fields;
   } else {
     var fields = copy.fields;
@@ -98,7 +98,11 @@ function * handleRequest(that, opts) {
     copy[opts.fieldsKey] = fields;
   }
 
-  copy[opts.filesKey] = files;
+  if (opts.filesKey === false) {
+    extend(false, copy, files);
+  } else {
+    copy[opts.filesKey] = files;
+  }
 
   return copy;
 }


### PR DESCRIPTION
Setting `filesKey` would store file fields directly on `this.request.body`. This would overwrite the text fields with the same name.

For issue #10
