### PR TITLE
Delete request fails

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,7 +96,9 @@ module.exports = function koaBetterBody(options) {
  * @api private
  */
 function * handleRequest(that, opts) {
-  var cache = {};
+  var cache = {
+    fields: {}
+  };
   var returns = {};
   var options = {
     encoding: opts.encode || opts.encoding,


### PR DESCRIPTION
We need a default value for cache.fields.

Context:
   fieldsKey is false
   filesKey is not false (any string)

When delete request is done no body is sent, so cache.fields is undefined and on line 119 returns puts to undefined the line 128 continues and code crashes.
