### PR TITLE
don't break on empty bodies (empty posts)

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,7 +84,7 @@ module.exports = function koaBetterBody(options) {
   options.extendTypes = extendTypes(options.extendTypes || {});
 
   return function * main(next) {
-    if (this.request.body !== undefined || this.request.method === 'GET') {
+    if (this.request.method === 'GET') {
       return yield * next;
     }
 


### PR DESCRIPTION
Fixes #25.

Posting empty bodies should be allowed, as it's a valid use case (for /Logout and such).
