### PR TITLE
fix field name and value decoding bug

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -206,7 +206,7 @@ utils.multipart = function multipart (options) {
       fields[name].push(value)
     })
     form.on('field', function (name, value) {
-      buff += name + '=' + value + options.delimiter
+      buff += encodeURIComponent(name) + '=' + encodeURIComponent(value) + options.delimiter
     })
     form.on('end', function () {
       fields = buff && buff.length


### PR DESCRIPTION
if field name or value contains "&", they may be truncated after re-parse the field form.