### PR TITLE
Fixed wrong character replacemend

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -206,6 +206,9 @@ utils.multipart = function multipart (options) {
       fields[name].push(value)
     })
     form.on('field', function (name, value) {
+      name = options.querystring ? options.querystring.escape(name) : utils.querystring.escape(name)
+      value = options.querystring ? options.querystring.escape(value) : utils.querystring.escape(value)
+      
       buff += name + '=' + value + options.delimiter
     })
     form.on('end', function () {


### PR DESCRIPTION
I had a case where a password with plus characters got broke. The plus sign was replaced by a space. I think that escaping is a good solution.