### PR TITLE
[BF] remove ctx.querystring when getting qs module from koa

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -144,7 +144,6 @@ utils.setParsers = function setParsers (ctx, opts) {
     opts.qs || // alias
     ctx.app && ctx.app.querystring ||
     ctx.app && ctx.app.qs || // alias
-    ctx.querystring ||
     ctx.qs // alias
 
   utils.bodyParsers(ctx)


### PR DESCRIPTION
a simple way to solve the issue [https://github.com/tunnckoCore/koa-better-body/issues/77#issuecomment-272590756](https://github.com/tunnckoCore/koa-better-body/issues/77#issuecomment-272590756)